### PR TITLE
Move timer cancel after play has been awaited

### DIFF
--- a/lib/src/video_player/video_player.dart
+++ b/lib/src/video_player/video_player.dart
@@ -459,9 +459,9 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     if (!_created || _isDisposed) {
       return;
     }
-    _timer?.cancel();
     if (value.isPlaying) {
       await _videoPlayerPlatform.play(_textureId);
+      _timer?.cancel();
       _timer = Timer.periodic(
         const Duration(milliseconds: 300),
         (Timer timer) async {
@@ -485,6 +485,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         },
       );
     } else {
+      _timer?.cancel();
       await _videoPlayerPlatform.pause(_textureId);
     }
   }


### PR DESCRIPTION
Currently the timer's cancel is before the `play()` which causes issues (player freezes after replaying the same video the 2nd-3rd time. 

I propose to use the same logic as the official `video_player`:

https://github.com/flutter/packages/blob/main/packages/video_player/video_player/lib/video_player.dart

This fixes the problem that I mentioned.