### PR TITLE
- Util.inferContentTypeForExtension argument extension value issue fix

### DIFF
--- a/android/src/main/kotlin/uz/shs/better_player_plus/BetterPlayer.kt
+++ b/android/src/main/kotlin/uz/shs/better_player_plus/BetterPlayer.kt
@@ -392,7 +392,7 @@ internal class BetterPlayer(
             if (lastPathSegment == null) {
                 lastPathSegment = ""
             }
-            type = Util.inferContentTypeForExtension(lastPathSegment)
+            type = Util.inferContentTypeForExtension(lastPathSegment.split(".")[1])
         } else {
             type = when (formatHint) {
                 FORMAT_SS -> C.CONTENT_TYPE_SS


### PR DESCRIPTION
Better player file in build media source function when media source format type is return always other due to lastPathSegment need to be mpd or mp4 but the value is "sample.mp4" and in Util.inferContentTypeForExtension is always return other and return wrong media source. The issue is happening when url is DASH mpd format and exoplayer has initalized wrong media source and DASH url can not play.