### PR TITLE
Add textAlignt to BetterPlayerSubtitlesConfiguration

### DIFF
--- a/lib/src/subtitles/better_player_subtitles_configuration.dart
+++ b/lib/src/subtitles/better_player_subtitles_configuration.dart
@@ -37,6 +37,9 @@ class BetterPlayerSubtitlesConfiguration {
   ///Background color of the subtitle
   final Color backgroundColor;
 
+  ///Subtitle text alignment
+  final TextAlign textAlign;
+
   const BetterPlayerSubtitlesConfiguration({
     this.fontSize = 14,
     this.fontColor = Colors.white,
@@ -49,5 +52,6 @@ class BetterPlayerSubtitlesConfiguration {
     this.bottomPadding = 20.0,
     this.alignment = Alignment.center,
     this.backgroundColor = Colors.transparent,
+    this.textAlign = TextAlign.center,
   });
 }

--- a/lib/src/subtitles/better_player_subtitles_drawer.dart
+++ b/lib/src/subtitles/better_player_subtitles_drawer.dart
@@ -158,8 +158,16 @@ class _BetterPlayerSubtitlesDrawerState
   }
 
   Widget _buildHtmlWidget(String text, TextStyle textStyle) {
+    final textAlign = _configuration!.textAlign.toString().split('.').last;
+    String styledHtml = '''
+<div style="
+  text-align: $textAlign;
+">
+  $text
+</div>
+''';
     return HtmlWidget(
-      text,
+      styledHtml,
       textStyle: textStyle,
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   wakelock_plus: ^1.2.4
   path_provider: ^2.1.3
   visibility_detector: ^0.4.0+2
-  flutter_widget_from_html_core: ^0.14.11
+  flutter_widget_from_html_core: ^0.16.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Now when the subtitle is a single line, this is text-align center. But if the number of lines > 1. The text-align is left
I fixed it by add text-align to the configuration
