### PR TITLE
Fix: Kotlin build errors

### DIFF
--- a/android/src/main/kotlin/uz/shs/better_player_plus/BetterPlayer.kt
+++ b/android/src/main/kotlin/uz/shs/better_player_plus/BetterPlayer.kt
@@ -399,9 +399,8 @@ internal class BetterPlayer(
             mediaItemBuilder.setCustomCacheKey(cacheKey)
         }
         val mediaItem = mediaItemBuilder.build()
-        var drmSessionManagerProvider: DrmSessionManagerProvider? = null
-        drmSessionManager?.let { drmSessionManager ->
-            drmSessionManagerProvider = DrmSessionManagerProvider { drmSessionManager }
+        val drmSessionManagerProvider: DrmSessionManagerProvider? = drmSessionManager?.let { drmSessionManager ->
+            DrmSessionManagerProvider { drmSessionManager }
         }
 
         return when (type) {
@@ -575,12 +574,12 @@ internal class BetterPlayer(
 
     val absolutePosition: Long
         get() {
-            val timeline = exoPlayer?.currentTimeline
-            timeline?.let {
+            exoPlayer?.let { player ->
+                val timeline = player.currentTimeline
                 if (!timeline.isEmpty) {
                     val windowStartTimeMs =
                         timeline.getWindow(0, Timeline.Window()).windowStartTimeMs
-                    val pos = exoPlayer.currentPosition
+                    val pos = player.currentPosition
                     return windowStartTimeMs + pos
                 }
             }
@@ -593,18 +592,19 @@ internal class BetterPlayer(
             event["event"] = "initialized"
             event["key"] = key
             event["duration"] = getDuration()
-            if (exoPlayer?.videoFormat != null) {
-                val videoFormat = exoPlayer.videoFormat
-                var width = videoFormat?.width
-                var height = videoFormat?.height
-                val rotationDegrees = videoFormat?.rotationDegrees
-                // Switch the width/height if video was taken in portrait mode
-                if (rotationDegrees == 90 || rotationDegrees == 270) {
-                    width = exoPlayer.videoFormat?.height
-                    height = exoPlayer.videoFormat?.width
+            exoPlayer?.let { player ->
+                player.videoFormat?.let { videoFormat ->
+                    var width = videoFormat.width
+                    var height = videoFormat.height
+                    val rotationDegrees = videoFormat.rotationDegrees
+                    // Switch the width/height if video was taken in portrait mode
+                    if (rotationDegrees == 90 || rotationDegrees == 270) {
+                        width = videoFormat.height
+                        height = videoFormat.width
+                    }
+                    event["width"] = width
+                    event["height"] = height
                 }
-                event["width"] = width
-                event["height"] = height
             }
             eventSink.success(event)
         }


### PR DESCRIPTION
Fix: use player reference when accessing DRM, timeline, and video format

- Simplify DrmSessionManagerProvider initialization using a safe let expression.
- Use a local player reference when reading currentTimeline and currentPosition to avoid nullable access.
- Guard videoFormat access with nested lets and set width/height only when available.

<img width="1270" height="183" alt="Screenshot 2025-11-04 at 12 08 08" src="https://github.com/user-attachments/assets/13201ff7-2adb-4159-9f35-8dfa502105bd" />
