### PR TITLE
fix: clear audio track overrides before adding new one

### DIFF
--- a/android/src/main/kotlin/uz/shs/better_player_plus/BetterPlayer.kt
+++ b/android/src/main/kotlin/uz/shs/better_player_plus/BetterPlayer.kt
@@ -721,15 +721,14 @@ internal class BetterPlayer(
                 val group = trackGroups.get(groupIndex)
                 val safeTrackIndex = trackIndex.coerceIn(0, group.length - 1)
 
-                val builder = trackSelector.parameters
-                    .buildUpon()
-                    .setRendererDisabled(rendererIndex, false)
-                    .addOverride(
-                        TrackSelectionOverride(
-                            group,
-                            safeTrackIndex
-                        )
-                    )
+		val builder = trackSelector.parameters
+    			.buildUpon()
+    			.setTrackTypeDisabled(C.TRACK_TYPE_AUDIO, false)
+    			.clearOverridesOfType(C.TRACK_TYPE_AUDIO)
+    			.addOverride(
+        			TrackSelectionOverride(group, safeTrackIndex)
+    			)
+
 
                 trackSelector.setParameters(builder)
             } else {


### PR DESCRIPTION
## Problem
`setAudioTrack()` does not work reliably on Android. After calling 
`setAudioTrack()`, the audio track does not change even though the 
method executes without errors.

## Root Cause
The private `setAudioTrack(rendererIndex, groupIndex, trackIndex)` 
method uses `addOverride()` without first calling 
`clearOverridesOfType(C.TRACK_TYPE_AUDIO)`. 

On Media3 1.8.0, when an audio track override already exists (e.g., 
from automatic first-track selection during initialization via 
`setupDataSource()`), `addOverride()` does not replace it — the 
existing override takes precedence and the new one is silently ignored.

## Fix
- Call `clearOverridesOfType(C.TRACK_TYPE_AUDIO)` before `addOverride()`
- Replace deprecated `setRendererDisabled()` with `setTrackTypeDisabled()`

## Testing
Tested on Android TV (emulator API 34) with HLS streams containing 
multiple audio tracks (Italian + English). Audio track switching now 
works correctly.