### PR TITLE
Fix controlsVisibilityStream not emitting on auto-hide

### DIFF
--- a/lib/src/controls/better_player_cupertino_controls.dart
+++ b/lib/src/controls/better_player_cupertino_controls.dart
@@ -467,6 +467,9 @@ class _BetterPlayerCupertinoControlsState extends BetterPlayerControlsState<Bett
       });
     }
     _controlsVisibilityStreamSubscription = _betterPlayerController!.controlsVisibilityStream.listen((state) {
+      if (controlsNotVisible == !state) {
+        return;
+      }
       changePlayerControlsNotVisible(!state);
 
       if (!controlsNotVisible) {

--- a/lib/src/controls/better_player_cupertino_controls.dart
+++ b/lib/src/controls/better_player_cupertino_controls.dart
@@ -557,6 +557,7 @@ class _BetterPlayerCupertinoControlsState extends BetterPlayerControlsState<Bett
 
   void _onPlayerHide() {
     _betterPlayerController!.toggleControlsVisibility(!controlsNotVisible);
+    _betterPlayerController!.setControlsVisibility(!controlsNotVisible);
     widget.onControlsVisibilityChanged(!controlsNotVisible);
   }
 

--- a/lib/src/controls/better_player_material_controls.dart
+++ b/lib/src/controls/better_player_material_controls.dart
@@ -492,6 +492,9 @@ class _BetterPlayerMaterialControlsState extends BetterPlayerControlsState<Bette
     }
 
     _controlsVisibilityStreamSubscription = _betterPlayerController!.controlsVisibilityStream.listen((state) {
+      if (controlsNotVisible == !state) {
+        return;
+      }
       changePlayerControlsNotVisible(!state);
       if (!controlsNotVisible) {
         cancelAndRestartTimer();

--- a/lib/src/controls/better_player_material_controls.dart
+++ b/lib/src/controls/better_player_material_controls.dart
@@ -579,6 +579,7 @@ class _BetterPlayerMaterialControlsState extends BetterPlayerControlsState<Bette
 
   void _onPlayerHide() {
     _betterPlayerController!.toggleControlsVisibility(!controlsNotVisible);
+    _betterPlayerController!.setControlsVisibility(!controlsNotVisible);
     widget.onControlsVisibilityChanged(!controlsNotVisible);
   }
 


### PR DESCRIPTION
Fixed an issue where controlsVisibilityStream from BetterPlayerController failed to reliably emit false when the UI auto-hides itself in both Material and Cupertino controls.
By invoking setControlsVisibility(!controlsNotVisible) inside the internal _onPlayerHide handlers, external StreamBuilder widgets listening to controlsVisibilityStream can now correctly rely on real-time visibility events.