### PR TITLE
Native subtitle support for WebVTT in fMP4 containers

### DIFF
--- a/android/src/main/kotlin/uz/shs/better_player_plus/BetterPlayer.kt
+++ b/android/src/main/kotlin/uz/shs/better_player_plus/BetterPlayer.kt
@@ -46,6 +46,7 @@ import androidx.media3.common.TrackSelectionOverride
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.common.util.Util
 import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.HttpDataSource
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.DefaultLoadControl

--- a/android/src/main/kotlin/uz/shs/better_player_plus/BetterPlayer.kt
+++ b/android/src/main/kotlin/uz/shs/better_player_plus/BetterPlayer.kt
@@ -43,6 +43,7 @@ import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
 import androidx.media3.common.TrackSelectionOverride
+import androidx.media3.common.text.CueGroup
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.common.util.Util
 import androidx.media3.datasource.DataSource
@@ -96,6 +97,7 @@ internal class BetterPlayer(
     private var refreshHandler: Handler? = null
     private var refreshRunnable: Runnable? = null
     private var exoPlayerEventListener: Player.Listener? = null
+    private var textTrackEnabled = true
     private var bitmap: Bitmap? = null
     private var mediaSession: MediaSessionCompat? = null
     private var drmSessionManager: DrmSessionManager? = null
@@ -114,6 +116,11 @@ internal class BetterPlayer(
             this.customDefaultLoadControl.bufferForPlaybackAfterRebufferMs
         )
         loadControl = loadBuilder.build()
+        // Pre confg track selector to allow text tracks with undetermined language
+        val initialParams = trackSelector.buildUponParameters()
+        initialParams.setSelectUndeterminedTextLanguage(true)
+        trackSelector.setParameters(initialParams)
+
         exoPlayer = ExoPlayer.Builder(context)
             .setTrackSelector(trackSelector)
             .setLoadControl(loadControl)
@@ -549,6 +556,24 @@ internal class BetterPlayer(
                 eventSink.error(errorCode.toString(), errorMessage, error)
             }
         })
+        // Listen for subtitle cues and track changes from ExoPlayer.
+        exoPlayer?.addListener(object : Player.Listener {
+            override fun onCues(cueGroup: CueGroup) {
+                val texts = cueGroup.cues.mapNotNull { it.text?.toString() }
+                val joined = texts.joinToString("\n")
+                val event: MutableMap<String, Any> = HashMap()
+                event["event"] = "subtitleCue"
+                event["subtitleText"] = joined
+                eventSink.success(event)
+            }
+
+            override fun onTracksChanged(tracks: androidx.media3.common.Tracks) {
+                if (textTrackEnabled) {
+                    selectFirstTextTrack()
+                }
+            }
+        })
+
         val reply: MutableMap<String, Any> = HashMap()
         reply["textureId"] = textureEntry.id()
         result.success(reply)
@@ -799,6 +824,41 @@ internal class BetterPlayer(
 
     fun setMixWithOthers(mixWithOthers: Boolean) {
         setAudioAttributes(exoPlayer, mixWithOthers)
+    }
+
+    fun enableTextTrack() {
+        textTrackEnabled = true
+        val parametersBuilder = trackSelector.buildUponParameters()
+        parametersBuilder.setTrackTypeDisabled(C.TRACK_TYPE_TEXT, false)
+        parametersBuilder.setSelectUndeterminedTextLanguage(true)
+        trackSelector.setParameters(parametersBuilder)
+        selectFirstTextTrack()
+    }
+
+    private fun selectFirstTextTrack() {
+        val mappedTrackInfo = trackSelector.currentMappedTrackInfo ?: return
+        for (i in 0 until mappedTrackInfo.rendererCount) {
+            if (mappedTrackInfo.getRendererType(i) == C.TRACK_TYPE_TEXT) {
+                val groups = mappedTrackInfo.getTrackGroups(i)
+                if (groups.length > 0) {
+                    val firstGroup = groups[0]
+                    val parametersBuilder = trackSelector.buildUponParameters()
+                    parametersBuilder.setTrackTypeDisabled(C.TRACK_TYPE_TEXT, false)
+                    parametersBuilder.setSelectUndeterminedTextLanguage(true)
+                    parametersBuilder.addOverride(TrackSelectionOverride(firstGroup, 0))
+                    trackSelector.setParameters(parametersBuilder)
+                }
+                return
+            }
+        }
+    }
+
+    fun disableTextTrack() {
+        textTrackEnabled = false
+        val parametersBuilder = trackSelector.buildUponParameters()
+        parametersBuilder.setTrackTypeDisabled(C.TRACK_TYPE_TEXT, true)
+        parametersBuilder.clearOverridesOfType(C.TRACK_TYPE_TEXT)
+        trackSelector.setParameters(parametersBuilder)
     }
 
     fun dispose() {

--- a/android/src/main/kotlin/uz/shs/better_player_plus/BetterPlayerPlugin.kt
+++ b/android/src/main/kotlin/uz/shs/better_player_plus/BetterPlayerPlugin.kt
@@ -248,6 +248,16 @@ class BetterPlayerPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
                 }
             }
 
+            ENABLE_TEXT_TRACK_METHOD -> {
+                player.enableTextTrack()
+                result.success(null)
+            }
+
+            DISABLE_TEXT_TRACK_METHOD -> {
+                player.disableTextTrack()
+                result.success(null)
+            }
+
             DISPOSE_METHOD -> {
                 dispose(player, textureId)
                 result.success(null)
@@ -583,6 +593,8 @@ class BetterPlayerPlugin : FlutterPlugin, ActivityAware, MethodCallHandler {
         private const val IS_PICTURE_IN_PICTURE_SUPPORTED_METHOD = "isPictureInPictureSupported"
         private const val SET_MIX_WITH_OTHERS_METHOD = "setMixWithOthers"
         private const val CLEAR_CACHE_METHOD = "clearCache"
+        private const val ENABLE_TEXT_TRACK_METHOD = "enableTextTrack"
+        private const val DISABLE_TEXT_TRACK_METHOD = "disableTextTrack"
         private const val DISPOSE_METHOD = "dispose"
         private const val PRE_CACHE_METHOD = "preCache"
         private const val STOP_PRE_CACHE_METHOD = "stopPreCache"

--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -727,7 +727,10 @@ class BetterPlayerController {
       _postEvent(
         BetterPlayerEvent(
           BetterPlayerEventType.exception,
-          parameters: <String, dynamic>{'exception': currentVideoPlayerValue.errorDescription},
+          parameters: <String, dynamic>{
+            "exception": currentVideoPlayerValue.errorDescription,
+            "errorCode": currentVideoPlayerValue.errorCode
+},
         ),
       );
     }

--- a/lib/src/core/better_player_controller.dart
+++ b/lib/src/core/better_player_controller.dart
@@ -210,6 +210,18 @@ class BetterPlayerController {
   ///Currently displayed [BetterPlayerSubtitle].
   BetterPlayerSubtitle? renderedSubtitle;
 
+  ///Current native subtitle cue text from platform player (ExoPlayer/AVPlayer).
+  String _nativeSubtitleText = '';
+
+  ///Current native subtitle cue text from platform player.
+  String get nativeSubtitleText => _nativeSubtitleText;
+
+  ///Whether native subtitle cues are being used.
+  bool _useNativeSubtitles = false;
+
+  ///Whether native subtitle cues are being used.
+  bool get useNativeSubtitles => _useNativeSubtitles;
+
   ///Get BetterPlayerController from context. Used in InheritedWidget.
   static BetterPlayerController of(BuildContext context) {
     final betterPLayerControllerProvider = context
@@ -1100,9 +1112,23 @@ class BetterPlayerController {
         );
       case VideoEventType.bufferingEnd:
         _postEvent(BetterPlayerEvent(BetterPlayerEventType.bufferingEnd));
+      case VideoEventType.subtitleCue:
+        _nativeSubtitleText = event.subtitleText ?? '';
+        _useNativeSubtitles = true;
       default:
         break;
     }
+  }
+
+  ///Enable native text track rendering (ExoPlayer/AVPlayer handles subtitles).
+  void enableNativeTextTrack() {
+    videoPlayerController?.enableTextTrack();
+  }
+
+  ///Disable native text track rendering.
+  void disableNativeTextTrack() {
+    _nativeSubtitleText = '';
+    videoPlayerController?.disableTextTrack();
   }
 
   ///Setup controls always visible mode

--- a/lib/src/subtitles/better_player_subtitles_drawer.dart
+++ b/lib/src/subtitles/better_player_subtitles_drawer.dart
@@ -54,6 +54,7 @@ class _BetterPlayerSubtitlesDrawerState extends State<BetterPlayerSubtitlesDrawe
     _outerTextStyle = TextStyle(
       fontSize: _configuration!.fontSize,
       fontFamily: _configuration!.fontFamily,
+      decoration: TextDecoration.none,
       foreground: Paint()
         ..style = PaintingStyle.stroke
         ..strokeWidth = _configuration!.outlineSize
@@ -64,6 +65,7 @@ class _BetterPlayerSubtitlesDrawerState extends State<BetterPlayerSubtitlesDrawe
       fontFamily: _configuration!.fontFamily,
       color: _configuration!.fontColor,
       fontSize: _configuration!.fontSize,
+      decoration: TextDecoration.none,
     );
 
     super.initState();
@@ -87,9 +89,17 @@ class _BetterPlayerSubtitlesDrawerState extends State<BetterPlayerSubtitlesDrawe
 
   @override
   Widget build(BuildContext context) {
-    final BetterPlayerSubtitle? subtitle = _getSubtitleAtCurrentPosition();
-    widget.betterPlayerController.renderedSubtitle = subtitle;
-    final List<String> subtitles = subtitle?.texts ?? [];
+    // Prefer native subtitle cues from ExoPlayer/AVPlayer when available.
+    final String nativeText = widget.betterPlayerController.nativeSubtitleText;
+    final List<String> subtitles;
+    if (widget.betterPlayerController.useNativeSubtitles && nativeText.isNotEmpty) {
+      subtitles = nativeText.split('\n');
+      widget.betterPlayerController.renderedSubtitle = null;
+    } else {
+      final BetterPlayerSubtitle? subtitle = _getSubtitleAtCurrentPosition();
+      widget.betterPlayerController.renderedSubtitle = subtitle;
+      subtitles = subtitle?.texts ?? [];
+    }
     final List<Widget> textWidgets = subtitles.map(_buildSubtitleTextWidget).toList();
 
     return SizedBox.expand(

--- a/lib/src/video_player/method_channel_video_player.dart
+++ b/lib/src/video_player/method_channel_video_player.dart
@@ -190,6 +190,18 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
   );
 
   @override
+  Future<void> enableTextTrack(int? textureId) => _channel.invokeMethod<void>(
+    'enableTextTrack',
+    <String, dynamic>{'textureId': textureId},
+  );
+
+  @override
+  Future<void> disableTextTrack(int? textureId) => _channel.invokeMethod<void>(
+    'disableTextTrack',
+    <String, dynamic>{'textureId': textureId},
+  );
+
+  @override
   Future<void> clearCache() => _channel.invokeMethod<void>('clearCache', <String, dynamic>{});
 
   @override
@@ -280,6 +292,13 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
 
           case 'pipStop':
             return VideoEvent(eventType: VideoEventType.pipStop, key: key);
+
+          case 'subtitleCue':
+            return VideoEvent(
+              eventType: VideoEventType.subtitleCue,
+              key: key,
+              subtitleText: map['subtitleText'] as String? ?? '',
+            );
 
           default:
             return VideoEvent(eventType: VideoEventType.unknown, key: key);

--- a/lib/src/video_player/method_channel_video_player.dart
+++ b/lib/src/video_player/method_channel_video_player.dart
@@ -149,6 +149,13 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
       return null;
     }
 
+    // Sometimes the media server returns a absolute position far greater than
+    // the datetime instance can handle. This caps the value to the maximum the datetime
+    // can use.
+    if (milliseconds > 8640000000000000 || milliseconds < -8640000000000000) {
+      return null;
+    }
+
     return DateTime.fromMillisecondsSinceEpoch(milliseconds);
   }
 

--- a/lib/src/video_player/video_player.dart
+++ b/lib/src/video_player/video_player.dart
@@ -31,6 +31,7 @@ class VideoPlayerValue {
     this.isBuffering = false,
     this.volume = 1.0,
     this.speed = 1.0,
+    this.errorCode,
     this.errorDescription,
     this.isPip = false,
   });
@@ -72,6 +73,11 @@ class VideoPlayerValue {
 
   /// The current speed of the playback
   final double speed;
+
+  /// A code of the error if present.
+  ///
+  /// If [hasError] is false this is [null].
+  final String? errorCode;
 
   /// A description of the error if present.
   ///
@@ -118,6 +124,7 @@ class VideoPlayerValue {
     bool? isLooping,
     bool? isBuffering,
     double? volume,
+    String? errorCode,
     String? errorDescription,
     double? speed,
     bool? isPip,
@@ -132,6 +139,7 @@ class VideoPlayerValue {
     isBuffering: isBuffering ?? this.isBuffering,
     volume: volume ?? this.volume,
     speed: speed ?? this.speed,
+    errorCode: errorCode ?? this.errorCode,
     errorDescription: errorDescription ?? this.errorDescription,
     isPip: isPip ?? this.isPip,
   );
@@ -148,6 +156,7 @@ class VideoPlayerValue {
       'isLooping: $isLooping, '
       'isBuffering: $isBuffering, '
       'volume: $volume, '
+      'errorCode: $errorCode, '
       'errorDescription: $errorDescription)';
 }
 
@@ -239,7 +248,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     void errorListener(Object object) {
       if (object is PlatformException) {
         final PlatformException e = object;
-        value = value.copyWith(errorDescription: e.message);
+        value = value.copyWith(errorDescription: e.message, errorCode: e.code);
       } else {
         value.copyWith(errorDescription: object.toString());
       }

--- a/lib/src/video_player/video_player.dart
+++ b/lib/src/video_player/video_player.dart
@@ -240,6 +240,9 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           value = value.copyWith(isPip: true);
         case VideoEventType.pipStop:
           value = value.copyWith(isPip: false);
+        case VideoEventType.subtitleCue:
+          // Handled via videoEventStreamController in BetterPlayerController
+          break;
         case VideoEventType.unknown:
           break;
       }
@@ -596,6 +599,14 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
 
   void setMixWithOthers(bool mixWithOthers) {
     _videoPlayerPlatform.setMixWithOthers(_textureId, mixWithOthers);
+  }
+
+  void enableTextTrack() {
+    _videoPlayerPlatform.enableTextTrack(_textureId);
+  }
+
+  void disableTextTrack() {
+    _videoPlayerPlatform.disableTextTrack(_textureId);
   }
 
   static Future<void> clearCache() async => _videoPlayerPlatform.clearCache();

--- a/lib/src/video_player/video_player_platform_interface.dart
+++ b/lib/src/video_player/video_player_platform_interface.dart
@@ -157,6 +157,14 @@ abstract class VideoPlayerPlatform {
     throw UnimplementedError('setMixWithOthers() has not been implemented.');
   }
 
+  Future<void> enableTextTrack(int? textureId) {
+    throw UnimplementedError('enableTextTrack() has not been implemented.');
+  }
+
+  Future<void> disableTextTrack(int? textureId) {
+    throw UnimplementedError('disableTextTrack() has not been implemented.');
+  }
+
   Future<void> clearCache() {
     throw UnimplementedError('clearCache() has not been implemented.');
   }
@@ -373,6 +381,7 @@ class VideoEvent {
     this.size,
     this.buffered,
     this.position,
+    this.subtitleText,
   });
 
   /// The type of the event.
@@ -400,6 +409,9 @@ class VideoEvent {
 
   ///Seek position
   final Duration? position;
+
+  ///Native subtitle cue text
+  final String? subtitleText;
 
   @override
   bool operator ==(Object other) =>
@@ -450,6 +462,9 @@ enum VideoEventType {
 
   /// Picture in picture mode has been dismissed
   pipStop,
+
+  /// Native subtitle cue received from platform player
+  subtitleCue,
 
   /// An unknown event has been received.
   unknown,


### PR DESCRIPTION
- Adds native ExoPlayer subtitle decoding for streams using WebVTT in fMP4 containers (wvtt codec), which the Dart side parser cannot handle.
- Extracted some of the VLC native support / demux and transform it to BetterPlayer