### PR TITLE
fix: resolve 'compilerOptions' error by applying kotlin android plugin

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.android.library")
+    id("org.jetbrains.kotlin.android")
 }
 
 group = "uz.shs.better_player_plus"


### PR DESCRIPTION
This PR fixes the Unresolved reference: compilerOptions Android build error introduced in v1.3.2 by properly applying the Kotlin Android plugin to the Gradle Kotlin DSL.

Issue no : [https://github.com/SunnatilloShavkatov/better_player_plus/issues/110]