### PR TITLE
fix: correct Simplified Chinese translations

### DIFF
--- a/lib/src/configuration/better_player_translations.dart
+++ b/lib/src/configuration/better_player_translations.dart
@@ -36,15 +36,15 @@ class BetterPlayerTranslations {
     generalDefaultError: '无法播放视频',
     generalNone: '没有',
     generalDefault: '默认',
-    generalRetry: '重試',
+    generalRetry: '重试',
     playlistLoadingNextVideo: '正在加载下一个视频',
     controlsLive: '直播',
     controlsNextVideoIn: '下一部影片',
     overflowMenuPlaybackSpeed: '播放速度',
     overflowMenuSubtitles: '字幕',
-    overflowMenuQuality: '质量',
-    overflowMenuAudioTracks: '音訊',
-    qualityAuto: '汽車',
+    overflowMenuQuality: '画质',
+    overflowMenuAudioTracks: '音轨',
+    qualityAuto: '自动',
   );
 
   factory BetterPlayerTranslations.hindi() => BetterPlayerTranslations(


### PR DESCRIPTION
## Changes

Fixed 4 incorrect Simplified Chinese strings in `BetterPlayerTranslations.chinese()`:

| Field | Before | After | Issue |
|-------|--------|-------|-------|
| `qualityAuto` | `汽车` (car) | `自动` (auto) | Wrong word entirely |
| `generalRetry` | `重試` | `重试` | Traditional → Simplified |
| `overflowMenuAudioTracks` | `音訊` | `音轨` | Traditional → Simplified |
| `overflowMenuQuality` | `质量` | `画质` | More natural for video UI context |

## Checklist
- [x] Only `better_player_translations.dart` modified
- [x] All other language factories untouched
- [x] Verified with `dart analyze` (zero issues)