### PR TITLE
fix(android): sync play/pause state from native player changes

### DIFF
--- a/android/src/main/kotlin/uz/shs/better_player_plus/BetterPlayer.kt
+++ b/android/src/main/kotlin/uz/shs/better_player_plus/BetterPlayer.kt
@@ -497,6 +497,15 @@ internal class BetterPlayer(
             override fun onPlayerError(error: PlaybackException) {
                 eventSink.error("VideoError", "Video player had error $error", "")
             }
+
+            override fun onIsPlayingChanged(isPlaying: Boolean) {
+                // Catches play/pause state changes triggered natively (e.g. the
+                // media notification's PlayerNotificationManager controls the
+                // ExoPlayer instance directly), which otherwise never reach Dart.
+                val event: MutableMap<String, Any> = HashMap()
+                event["event"] = if (isPlaying) "play" else "pause"
+                eventSink.success(event)
+            }
         })
         val reply: MutableMap<String, Any> = HashMap()
         reply["textureId"] = textureEntry.id()


### PR DESCRIPTION
PlayerNotificationManager controls ExoPlayer directly via ForwardingPlayer (e.g. notification-center pause), bypassing the plugin's pause()/play() Dart method calls entirely. The Player.Listener never reported isPlaying changes back to Dart, so
VideoPlayerController.value.isPlaying stayed stale and UI (play/pause icon) didn't reflect state changes triggered outside the app (media notification, headset button, etc).

Add onIsPlayingChanged to emit the existing "play"/"pause" event, which the Dart side (video_player.dart) already handles via VideoEventType.play/.pause.