### PR TITLE
fix: set software decoder fallback to fix hardware decoder failure

### DIFF
--- a/android/src/main/kotlin/uz/shs/better_player_plus/BetterPlayer.kt
+++ b/android/src/main/kotlin/uz/shs/better_player_plus/BetterPlayer.kt
@@ -49,6 +49,7 @@ import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.DefaultLoadControl
+import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.LoadControl
 import androidx.media3.exoplayer.dash.DashMediaSource
@@ -113,7 +114,10 @@ internal class BetterPlayer(
             this.customDefaultLoadControl.bufferForPlaybackAfterRebufferMs
         )
         loadControl = loadBuilder.build()
+        val renderersFactory = DefaultRenderersFactory(context)
+            .setEnableDecoderFallback(true)
         exoPlayer = ExoPlayer.Builder(context)
+            .setRenderersFactory(renderersFactory)
             .setTrackSelector(trackSelector)
             .setLoadControl(loadControl)
             .build()


### PR DESCRIPTION
this might fix some playback issues on some android device like XiaoMi  MIX Flip with snapdragon 8 gen 3, but failed to playback some mp4 format because of its xiaomi own android software bugs on the support to media 3.
if specifying a default fallback to software decoding,  this might fix the issues (#76 )
