### PR TITLE
fix(ios): black video in the iOS Simulator (skip video composition)

### DIFF
--- a/ios/better_player_plus/Sources/better_player_plus/BetterPlayer.swift
+++ b/ios/better_player_plus/Sources/better_player_plus/BetterPlayer.swift
@@ -246,8 +246,16 @@ public class BetterPlayer: NSObject, FlutterPlatformView, FlutterStreamHandler, 
                         guard let self = self, !self.disposed else { return }
                         if videoTrack.statusOfValue(forKey: "preferredTransform", error: nil) == .loaded {
                             self.preferredTransform = self.fixTransform(videoTrack)
+                            // Skip the video composition in the Simulator: an AVPlayerItem
+                            // with a videoComposition renders black there (audio keeps
+                            // playing) — the compositing render path has no working
+                            // implementation in the Simulator. AVPlayerLayer applies
+                            // preferredTransform on its own, so rotated videos still
+                            // display correctly; devices keep the composition unchanged.
+                            #if !targetEnvironment(simulator)
                             let videoComposition = self.getVideoComposition(transform: self.preferredTransform, asset: asset, videoTrack: videoTrack)
                             item.videoComposition = videoComposition
+                            #endif
                         }
                     }
                 }


### PR DESCRIPTION
## Symptom

On the iOS Simulator every video plays audio but renders black — both the inline `AVPlayerLayer` and the Picture-in-Picture window. Real devices are unaffected.

## Cause

`setDataSourcePlayerItem` puts an `AVMutableVideoComposition` (the rotation fix) on every `AVPlayerItem`, even for videos with no rotation at all. A set `videoComposition` forces AVFoundation into the compositing render path, which has no working implementation in the iOS Simulator — so every layer attached to the item stays black while audio keeps playing.

## Fix

Skip the composition under `#if !targetEnvironment(simulator)`. `AVPlayerLayer` applies `preferredTransform` on its own, so rotated videos still display correctly in the Simulator; device behavior is unchanged (the composition is still applied there).

## Testing

- Before: iPad Air 11" (M4) Simulator, iOS 26.5 — local MP4 playback: audio only, inline player and PiP window black.
- After: same setup renders video in both the inline player and the PiP window.
- Real device (iPhone, iOS 18): behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)